### PR TITLE
Add a docker compose to clean up containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn
 # install
 COPY client /app/client
 RUN --mount=type=cache,target=/usr/local/share/.cache/yarn-${TARGETARCH} yarn build
+COPY docker-compose.yaml docker-compose.yaml
 
 
 FROM debian:bullseye-slim

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -264,6 +264,8 @@ const App = () => {
               'mongo',
               '-v',
               volumeDir + '/data:/data/db',
+              "--label",
+              "com.docker.compose.project=microcks_microcks-docker-desktop-extension-desktop-extension",
               'mongo:3.4.23',
             ],
             { stream: buildStreamingOpts(MONGO_CONTAINER, setMongoStatus) },
@@ -287,6 +289,8 @@ const App = () => {
               EXTENSION_NETWORK,
               '--hostname',
               'postman',
+              "--label",
+              "com.docker.compose.project=microcks_microcks-docker-desktop-extension-desktop-extension",
               'quay.io/microcks/microcks-postman-runtime:latest',
             ],
             {
@@ -336,6 +340,8 @@ const App = () => {
           `${8080 + config.portOffset}:8080`,
           '-p',
           `${9090 + config.portOffset}:9090`,
+          "--label",
+          "com.docker.compose.project=microcks_microcks-docker-desktop-extension-desktop-extension",
           'quay.io/microcks/microcks:latest',
         ];
         if (!appStatus.exists) {
@@ -370,6 +376,8 @@ const App = () => {
             KAFKA_CONTAINER,
             '--network',
             EXTENSION_NETWORK,
+            "--label",
+            "com.docker.compose.project=microcks_microcks-docker-desktop-extension-desktop-extension",
             '--hostname',
             'kafka',
             '-p',
@@ -425,6 +433,8 @@ const App = () => {
                 'on-failure',
                 '-p',
                 `${8081 + config.portOffset}:8081`,
+                "--label",
+                "com.docker.compose.project=microcks_microcks-docker-desktop-extension-desktop-extension",
                 'quay.io/microcks/microcks-async-minion:latest',
               ],
               {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,59 +1,7 @@
 services:
-  mongo:
-    image: mongo:3.4.23
-    container_name: microcks-db
-    volumes:
-      - "~/tmp/microcks-data:/data/db"
-
-  postman:
-    image: quay.io/microcks/microcks-postman-runtime:latest
-    container_name: microcks-postman-runtime
-
-  kafka:
-    image: vectorized/redpanda:v21.10.2
-    container_name: microcks-kafka
-    command: [
-      "redpanda", "start",
-      "--overprovisioned --smp 1  --memory 1G --reserve-memory 0M --node-id 0 --check=false",
-      "--kafka-addr PLAINTEXT://0.0.0.0:19092,EXTERNAL://0.0.0.0:9092",
-      "--advertise-kafka-addr PLAINTEXT://kafka:19092,EXTERNAL://localhost:9092"
-    ]
-    ports:
-      - "9092:9092"
-      - "19092:19092"
-
-  app:
-    depends_on:
-      - mongo
-      - postman
-    image: quay.io/microcks/microcks:latest
-    container_name: microcks
-    volumes:
-      - "./config:/deployments/config"
-    ports:
-      - "8080:8080"
-      - "9090:9090"
-    environment:
-      - SPRING_PROFILES_ACTIVE=prod
-      - SPRING_DATA_MONGODB_URI=mongodb://mongo:27017
-      - SPRING_DATA_MONGODB_DATABASE=microcks
-      - POSTMAN_RUNNER_URL=http://postman:3000
-      - TEST_CALLBACK_URL=http://microcks:8080
-      - SERVICES_UPDATE_INTERVAL=0 0 0/2 * * *
-      - KEYCLOAK_ENABLED=false
-      #- MAX_UPLOAD_FILE_SIZE=3MB
-      - ASYNC_MINION_URL=http://microcks-async-minion:8081
-      - KAFKA_BOOTSTRAP_SERVER=kafka:19092
-
-  async-minion:
-    depends_on:
-      - app
-    ports:
-      - "8081:8081"
-    image: quay.io/microcks/microcks-async-minion:latest
-    container_name: microcks-async-minion
-    restart: on-failure
-    volumes:
-      - "./config:/deployments/config"
-    environment:
-      - QUARKUS_PROFILE=docker-compose
+  microcks:
+    image: busybox
+    entrypoint: "echo microcks extension ready - This service is stopped by default."
+    deploy:
+      restart_policy:
+        condition: on-failure

--- a/metadata.json
+++ b/metadata.json
@@ -7,6 +7,9 @@
       "src": "index.html"
     }
   },
+  "vm": {
+    "composefile": "docker-compose.yaml"
+  },
   "host": {
     "binaries": [
       {


### PR DESCRIPTION
## Why
For now the Extensions SDK does not provide a clear way of cleaning up all containers that are dynamically started within an extension when the extension is uninstalled. 

We will provide a mechanism to perform some cleanup as transparent as possible for all extension developers. For now, we think this can be a good workaround in the meantime.

## What does this PR do?

This PR creates an almost empty compose file so that we can clean up all dynamically ran containers by just manually setting a label when we do a `docker run` inside the extension.

When you launch Microcks, you can now see that every container is inside a Stack in the Containers tab in Docker Desktop.

---

The drawback of this would be that there is one extra container (and the user might not even be aware if they choose not to see the Extensions containers in Docker Desktop) in the stack that will be stopped. The extra container that is stopped on startup it is not a concern for us, specially having in mind that this can be removed in a future version when we release the cleanup feature in the SDK.

Let me know your thoughts about this PR and if this works for you as a workaround in the meantime.