### PR TITLE
feat: #13 Make postman runtime container deployment optional

### DIFF
--- a/client/src/components/Footer.tsx
+++ b/client/src/components/Footer.tsx
@@ -24,7 +24,7 @@ const Footer: React.FC = ({ children }) => {
     <Box textAlign="center" paddingBottom={3} marginTop="auto">
       {children}
       <Typography color="InactiveCaptionText">
-        Copyright 2022 Microcks. All rights reserved.
+        Copyright 2023 Microcks. All rights reserved.
       </Typography>
     </Box>
   );

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -97,7 +97,7 @@ const Settings: React.FC<Props> = ({
                   onChange={handleChange}
                 />
               }
-              label={<Typography variant="subtitle1">Enable Postman Runtime</Typography>}
+              label={<Typography variant="subtitle1">Enable testing with Postman</Typography>}
             />
           </FormControl>
           <TextField

--- a/client/src/components/Settings.tsx
+++ b/client/src/components/Settings.tsx
@@ -46,7 +46,7 @@ const Settings: React.FC<Props> = ({
   handleCloseDialog,
   config,
 }) => {
-  const [{ portOffset, asyncEnabled }, setLocalConfig] = useState(config);
+  const [{ portOffset, asyncEnabled, postmanEnabled }, setLocalConfig] = useState(config);
 
   useEffect(() => {
     if (config) {
@@ -89,6 +89,16 @@ const Settings: React.FC<Props> = ({
               }
               label={<Typography variant="subtitle1">Enable Asynchronous APIs</Typography>}
             />
+            <FormControlLabel
+              control={
+                <Checkbox
+                  name="postmanEnabled"
+                  checked={postmanEnabled}
+                  onChange={handleChange}
+                />
+              }
+              label={<Typography variant="subtitle1">Enable Postman Runtime</Typography>}
+            />
           </FormControl>
           <TextField
             id="portoffset"
@@ -129,6 +139,7 @@ const Settings: React.FC<Props> = ({
           onClick={(event) =>
             handleClose({
               asyncEnabled: asyncEnabled,
+              postmanEnabled: postmanEnabled,
               portOffset: portOffset,
             })
           }

--- a/client/src/types/ExtensionConfig.ts
+++ b/client/src/types/ExtensionConfig.ts
@@ -18,5 +18,6 @@
  */
 export class ExtensionConfig {
   asyncEnabled: boolean = false;
+  postmanEnabled: boolean = false;
   portOffset: number = 0;
 }


### PR DESCRIPTION
### Description

- Add a new `postmanEnabled` settings in config and Settings pane
- Remove `POSTMAN_CONTAINER` from the list of default containers
- Add guards to only manage `POSTMAN_CONTAINER` if `postmanEnabled` is true
- chore: Update copyright date on Footer.tsx

### Related issue(s)

Resolves #13