### PR TITLE
Implement component for Mock URL rows

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -67,6 +67,7 @@ import Services from './components/Services';
 import { useDockerDesktopClient } from './utils/ddclient';
 import { ExecStreamOptions } from '@docker/extension-api-client-types/dist/v1';
 import AlertDialog from './components/AlertDialog';
+import ClipboardCopy from './components/ClipboardCopy';
 
 const isWindows = () => {
   const platform = useDockerDesktopClient().host.platform;
@@ -970,11 +971,24 @@ const App = () => {
                   component="span"
                 >
                   http://localhost:{8080 + config.portOffset}
+                </Link>
+                <IconButton
+                  onClick={() =>
+                    ddClient.host.openExternal(
+                      `http://localhost:${8080 + config.portOffset}/#/`,
+                    )
+                  }
+                  component="span"
+                  size="small"
+                >
                   <OpenInNewIcon
                     fontSize="small"
-                    style={{ verticalAlign: 'middle' }}
                   />
-                </Link>
+                </IconButton>
+                <ClipboardCopy
+                  copyText={`http://localhost:${8080 + config.portOffset}/#/`}
+                  size="small"
+                />
               </Typography>
             </Box>
           </Paper>
@@ -998,7 +1012,12 @@ const App = () => {
         open={openDeleteDialog}
         closeHandler={handleCloseDeleteDialog}
       />
-      <AlertDialog title={alertDialogData.title} text={alertDialogData.text} open={openAlertDialog} closeHandler={handleCloseAlertDialog}/>
+      <AlertDialog
+        title={alertDialogData.title}
+        text={alertDialogData.text}
+        open={openAlertDialog}
+        closeHandler={handleCloseAlertDialog}
+      />
       <Backdrop
         sx={{ color: '#fff', zIndex: (theme) => theme.zIndex.drawer + 1 }}
         open={isLoading}

--- a/client/src/components/ClipboardCopy.tsx
+++ b/client/src/components/ClipboardCopy.tsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react'
+import React, { useState } from 'react';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import IconButton from '@mui/material/IconButton';
 import Tooltip from '@mui/material/Tooltip';
 
-const ClipboardCopy: React.FC<{copyText:string}> = ({ copyText }) => {
+const ClipboardCopy: React.FC<{ copyText: string, size?: 'small'| 'medium' | 'large' }> = ({ copyText, size }) => {
   const [isCopied, setIsCopied] = useState(false);
 
   const copyTextToClipboard = async (text: string) => {
@@ -30,13 +30,12 @@ const ClipboardCopy: React.FC<{copyText:string}> = ({ copyText }) => {
   };
 
   return (
-    <Tooltip title={isCopied ? 'Copied!': 'Copy'}>
-
-    <IconButton onClick={handleCopyClick}>
-      <ContentCopyIcon/>
-    </IconButton>
+    <Tooltip title={isCopied ? 'Copied!' : 'Copy'}>
+      <IconButton onClick={handleCopyClick} component="span" size={size}>
+        <ContentCopyIcon fontSize={size}/>
+      </IconButton>
     </Tooltip>
   );
 };
 
-export default ClipboardCopy
+export default ClipboardCopy;

--- a/client/src/components/MockURLRow.tsx
+++ b/client/src/components/MockURLRow.tsx
@@ -1,0 +1,39 @@
+import LaunchIcon from '@mui/icons-material/Launch';
+import IconButton from '@mui/material/IconButton';
+import Link from '@mui/material/Link';
+import Typography from '@mui/material/Typography';
+import React from 'react';
+import { useDockerDesktopClient } from '../utils/ddclient';
+import ClipboardCopy from './ClipboardCopy';
+
+interface MockURLRowProps {
+  mockURL: string;
+}
+
+const MockURLRow: React.FC<MockURLRowProps> = ({ mockURL }) => {
+  const ddClient = useDockerDesktopClient();
+
+  return (
+    <Typography noWrap>
+      <Link
+        onClick={() => ddClient.host.openExternal(mockURL)}
+        variant="subtitle1"
+        underline="hover"
+      >
+        {mockURL}
+      </Link>
+      <IconButton
+        onClick={() =>
+          ddClient.host.openExternal(mockURL)
+        }
+        component="span"
+        size='small'
+      >
+        <LaunchIcon />
+      </IconButton>
+      <ClipboardCopy copyText={mockURL} />
+    </Typography>
+  );
+};
+
+export default MockURLRow;

--- a/client/src/components/ServiceType.tsx
+++ b/client/src/components/ServiceType.tsx
@@ -16,8 +16,8 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-import React, { FC } from 'react';
 import Chip from '@mui/material/Chip';
+import { FC } from 'react';
 
 interface ServiceTypeProps {
   type: string;

--- a/client/src/components/Services.tsx
+++ b/client/src/components/Services.tsx
@@ -23,7 +23,6 @@ import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Collapse from '@mui/material/Collapse';
 import IconButton from '@mui/material/IconButton';
-import Link from '@mui/material/Link';
 import List from '@mui/material/List';
 import ListItem from '@mui/material/ListItem';
 import Stack from '@mui/material/Stack';
@@ -39,7 +38,7 @@ import { APP_CONTAINER } from '../utils/constants';
 import { useDockerDesktopClient } from '../utils/ddclient';
 
 import { ExtensionConfig } from '../types/ExtensionConfig';
-import ClipboardCopy from './ClipboardCopy';
+import MockURLRow from './MockURLRow';
 import ServiceType from './ServiceType';
 
 type Service = {
@@ -199,7 +198,7 @@ const Services = (props: { config: ExtensionConfig }) => {
                             </TableCell>
                             <TableCell>
                               <Typography variant="body1" component="span">
-                                {operation.name}
+                                {operation.name.replace(operation.method, '')}
                               </Typography>
                             </TableCell>
                             <TableCell>
@@ -223,44 +222,27 @@ const Services = (props: { config: ExtensionConfig }) => {
                                 </Box>
                               ) : operation.resourcePaths ? (
                                 <List>
-                                  {operation.resourcePaths.map((path, index) => (
-                                    <ListItem key={index} disablePadding>
-                                      <Link
-                                        onClick={() =>
-                                          ddClient.host.openExternal(
-                                            formatMockUrl(row, operation, path),
-                                          )
-                                        }
-                                        variant="subtitle1"
-                                        component="span"
-                                      >
-                                        {formatMockUrl(row, operation, path)}
-                                      </Link>
-                                      <ClipboardCopy
-                                        copyText={formatMockUrl(
-                                          row,
-                                          operation,
-                                          path,
-                                        )}
-                                      />
-                                    </ListItem>
-                                  ))}
+                                  {operation.resourcePaths.map(
+                                    (path, index) => (
+                                      <ListItem key={index} disablePadding>
+                                        <MockURLRow
+                                          mockURL={formatMockUrl(
+                                            row,
+                                            operation,
+                                            path,
+                                          )}
+                                        />
+                                      </ListItem>
+                                    ),
+                                  )}
                                 </List>
                               ) : (
                                 <>
-                                  <Link
-                                    onClick={() =>
-                                      ddClient.host.openExternal(
-                                        formatMockUrl(row, operation),
-                                      )
-                                    }
-                                    variant="subtitle1"
-                                    component="span"
-                                  >
-                                    {formatMockUrl(row, operation)}
-                                  </Link>
-                                  <ClipboardCopy
-                                    copyText={formatMockUrl(row, operation)}
+                                  <MockURLRow
+                                    mockURL={formatMockUrl(
+                                      row,
+                                      operation,
+                                    )}
                                   />
                                 </>
                               )}

--- a/client/src/components/Services.tsx
+++ b/client/src/components/Services.tsx
@@ -223,8 +223,8 @@ const Services = (props: { config: ExtensionConfig }) => {
                                 </Box>
                               ) : operation.resourcePaths ? (
                                 <List>
-                                  {operation.resourcePaths.map((path) => (
-                                    <ListItem disablePadding>
+                                  {operation.resourcePaths.map((path, index) => (
+                                    <ListItem key={index} disablePadding>
                                       <Link
                                         onClick={() =>
                                           ddClient.host.openExternal(


### PR DESCRIPTION


### Description

- Implement independent buttons for Open In new and Copy To Clipboard through a new MockURL component

### Related issue(s)

- V2