### PR TITLE
fix: handle another error thrown by Docker on unknown network

### DIFF
--- a/client/src/api/network.ts
+++ b/client/src/api/network.ts
@@ -29,7 +29,7 @@ export async function ensureNetworkExists(): Promise<boolean> {
   try {
     networkResult = await ddClient.docker.cli.exec("network", ["inspect", EXTENSION_NETWORK]);
   } catch (e: any) {
-    if (e.stderr !== undefined && (e.stderr.includes('No such network'))) {
+    if (e.stderr?.includes('No such network') || e.stderr?.includes('not found')) {
       // Create missing network for our extension.
       console.info('Creating a bridge network for extension.');
       try {


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

on my system, `docker network inspect <network>` returns 'not found' instead of `No such network`

```
$ docker network inspect foobar                                                                                                                                                                              []
Error response from daemon: network foobar not found
```

### Related issue(s)

fixes https://github.com/microcks/microcks-docker-desktop-extension/issues/20
