### PR TITLE
chore: handle other kind of errors from other engines

### DIFF
--- a/client/src/api/containers.ts
+++ b/client/src/api/containers.ts
@@ -52,7 +52,7 @@ export async function getContainerInfo(
       info.exists = false;
     }
   } catch (e: any) {
-    if (e.stderr !== undefined && e.stderr.includes('No such object')) {
+    if (e.stderr !== undefined && e.stderr.toLowerCase().includes('no such object')) {
       console.info(
         container +
           ' info - exists: ' +

--- a/client/src/api/volume.ts
+++ b/client/src/api/volume.ts
@@ -29,7 +29,7 @@ export async function ensureVolumeExists(): Promise<boolean> {
   try {
     volumeResult = await ddClient.docker.cli.exec("volume", ["inspect", EXTENSION_VOLUME]);
   } catch (e: any) {
-    if (e.stderr !== undefined && (e.stderr.includes('No such volume'))) {
+    if (e.stderr !== undefined && (e.stderr.toLowerCase().includes('no such volume'))) {
       // Create missing volume for our extension.
       console.info('Creating a volume for extension data.');
       try {


### PR DESCRIPTION
### Description

podman engine report errors with a lowercase so ignore case

```
$ podman inspect foo                                                                                                                                                                                       []
Error: inspecting object: no such object: "foo"
```

```
$ docker inspect foo                                                                                                                                                                                   []
Error: No such object: foo
```



### Related issue(s)

Trying with podman engine