### PR TITLE
chore: change the hostname of mongodb

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -314,7 +314,7 @@ const App = () => {
             '-e',
             'KAFKA_BOOTSTRAP_SERVER=kafka:19092',
             '-e',
-            'SPRING_DATA_MONGODB_URI=mongodb://mongo:27017',
+            'SPRING_DATA_MONGODB_URI=mongodb://microcks-mongodb:27017',
             '-e',
             'SPRING_DATA_MONGODB_DATABASE=microcks',
             '-e',


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

### Description

podman is not able to reach mongo host

But as mongodb container is started with the name `microcks-mongodb`, reuse the container name as hostname so other containers on the same network can also reach it

Please check on your side on Docker

### Related issue(s)

<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->